### PR TITLE
24 add endpoint users me to the api

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,6 @@
 class UsersController < ApplicationController
+  before_action :authenticate_user!
+
   def me
     render json: {
       data: {

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,2 +1,11 @@
 class UsersController < ApplicationController
+  def me
+    render json: {
+      data: {
+        token: request.headers['Authorization'].split[1],
+        name: current_user.name,
+        role: current_user.role
+      }
+    }
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,8 @@ Rails.application.routes.draw do
   resources :mentors, only: %i[index show create destroy] do
     resources :mentor_topics, path: "topics", only: %i[index create destroy]
   end
+  get 'users/me'
+
   devise_for :users,
     controllers: {
       registrations: :registrations,

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -28,7 +28,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_07_143349) do
     t.string "photo"
     t.string "name"
     t.string "bio"
-    t.bigint "user_id"
+    t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_mentors_on_user_id"

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -4,20 +4,20 @@ RSpec.describe Reservation, type: :model do
   before(:each) do
     load 'db/seeds.rb'
   end
-  subject { Reservation.new(user: User.second, mentor_topic: MentorTopic.last, date: '13/07/2022') }
+  subject { Reservation.new(user: User.second, mentor_topic: MentorTopic.last, date: Time.now.to_date) }
 
   describe 'reservation' do
     context 'with valid parameters' do
       it 'should save the reservation to the database' do
         expect do
-          subject.save
+          subject.save!
         end.to change(Reservation, :count).by(1)
       end
       it 'should save the reservation with the correct data' do
         subject.save
         expect(Reservation.last.user.name).to eq(User.second.name)
         expect(Reservation.last.mentor_topic.topic.label).to eq(MentorTopic.last.topic.label)
-        expect(Reservation.last.date).to eq('13/07/2022'.to_date)
+        expect(Reservation.last.date).to eq(Time.now.to_date)
       end
     end
   end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'Users', type: :request do
   before(:each) do
-    load 'db/seeds.rb'
+    # load 'db/seeds.rb'
     @admin_user = User.first
     @basic_user = User.last
   end
@@ -106,6 +106,33 @@ RSpec.describe 'Users', type: :request do
                 'is invalid'
               ]
             }
+          }
+        )
+      end
+    end
+  end
+
+  before do
+    @token = @basic_user.generate_jwt
+  end
+
+  let(:valid_headers) do
+    {
+      Authorization: "Bearer #{@token}"
+    }
+  end
+
+  describe 'GET /users/me' do
+    context 'with valid headers' do
+      it 'Renders a json response with token and user data' do
+        get users_me_url, headers: valid_headers
+        expect(response).to have_http_status(:ok)
+        json_body = JSON.parse(response.body)
+        expect(json_body).to match(
+          'data' => {
+            'token' => @token,
+            'name' => @basic_user.name,
+            'role' => @basic_user.role
           }
         )
       end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'Users', type: :request do
   before(:each) do
-    # load 'db/seeds.rb'
+    load 'db/seeds.rb'
     @admin_user = User.first
     @basic_user = User.last
   end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -137,5 +137,12 @@ RSpec.describe 'Users', type: :request do
         )
       end
     end
+
+    context 'with no headers' do
+      it 'Responds user unauthorized' do
+        get users_me_url
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
   end
 end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -122,6 +122,12 @@ RSpec.describe 'Users', type: :request do
     }
   end
 
+  let(:invalid_headers) do
+    {
+      Authorization: 'Bearer any_invalid_token'
+    }
+  end
+
   describe 'GET /users/me' do
     context 'with valid headers' do
       it 'Renders a json response with token and user data' do
@@ -141,6 +147,13 @@ RSpec.describe 'Users', type: :request do
     context 'with no headers' do
       it 'Responds user unauthorized' do
         get users_me_url
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'with invalid authorization token' do
+      it 'Responds user unauthorized' do
+        get users_me_url, headers: invalid_headers
         expect(response).to have_http_status(:unauthorized)
       end
     end


### PR DESCRIPTION
In this PR, the following changes were introduced:

- [x] Add endpoint "users/me" to return the authentication token, name, and role of the logged-in user.
- [x] Add tests for the endpoint.

![image](https://user-images.githubusercontent.com/73714615/179052905-4e2b9cab-e4d9-4393-9c7c-8007119d34ca.png)
