### PR TITLE
Make mentor topic index public

### DIFF
--- a/app/controllers/mentors_controller.rb
+++ b/app/controllers/mentors_controller.rb
@@ -6,12 +6,12 @@ class MentorsController < ApplicationController
 
   # GET /mentors
   def index
-    @mentors = Mentor.all
+    @mentors = Mentor.all.as_json(include: :mentor_topics)
 
     render json: { data: @mentors }
   end
 
-  # GET /mentors/1
+  # GET /mentors/1a
   def show
     render json: { data: @mentor }
   end

--- a/app/controllers/mentors_controller.rb
+++ b/app/controllers/mentors_controller.rb
@@ -6,7 +6,11 @@ class MentorsController < ApplicationController
 
   # GET /mentors
   def index
-    @mentors = Mentor.all.as_json(include: :mentor_topics)
+    @mentors = Mentor.all.as_json(
+      include: {
+        mentor_topics: { include: :topic }
+      }
+    )
 
     render json: { data: @mentors }
   end

--- a/app/controllers/mentors_controller.rb
+++ b/app/controllers/mentors_controller.rb
@@ -6,7 +6,7 @@ class MentorsController < ApplicationController
 
   # GET /mentors
   def index
-    @mentors = Mentor.all.as_json(
+    @mentors = Mentor.all.includes(mentor_topics: [:topic]).as_json(
       include: {
         mentor_topics: { include: :topic }
       }


### PR DESCRIPTION
In this PR, the following changes were introduced:

- [x] Let all users without login to be able to all and get list of topics related to a given mentor
- [x] Include mentorTopics in mentors detail so that when we get details for a given user, we get their topics as well.

![image](https://user-images.githubusercontent.com/73714615/179187117-b7f01e60-28f2-46fd-8664-c510d8f1cd29.png)
