### PR TITLE
Fix n+1 queries in reservations#index

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -5,7 +5,7 @@ class ReservationsController < ApplicationController
 
   # GET /reservations
   def index
-    @reservations = current_user.reservations.as_json(
+    @reservations = current_user.reservations.includes(:mentor, :user, :topic).as_json(
       only: %i[id date],
       include: {
         mentor: {


### PR DESCRIPTION
In this PR, the following changes were introduced:

- [x] In the reservation Controller, the index should not make n+1 calls in a loop.

![image](https://user-images.githubusercontent.com/73714615/179581075-59e9506d-89c3-4540-8b5f-c4e5a133fd1d.png)
